### PR TITLE
Disable tools for Player2 provider

### DIFF
--- a/apps/stage-tamagotchi/src/components/InteractiveArea.vue
+++ b/apps/stage-tamagotchi/src/components/InteractiveArea.vue
@@ -32,6 +32,7 @@ async function handleSend() {
     await send(messageInput.value, {
       model: activeModel.value,
       chatProvider: providersStore.getProviderInstance(activeProvider.value) as ChatProvider,
+      providerId: activeProvider.value,
       providerConfig,
     })
   }

--- a/apps/stage-web/src/components/Layouts/InteractiveArea.vue
+++ b/apps/stage-web/src/components/Layouts/InteractiveArea.vue
@@ -41,6 +41,7 @@ const { transcribe: generate, terminate } = useWhisper(WhisperWorker, {
     await send(res, {
       chatProvider: providersStore.getProviderInstance(activeProvider.value) as ChatProvider,
       model: activeModel.value,
+      providerId: activeProvider.value,
       providerConfig,
     })
   },
@@ -57,6 +58,7 @@ async function handleSend() {
     await send(messageInput.value, {
       chatProvider: providersStore.getProviderInstance(activeProvider.value) as ChatProvider,
       model: activeModel.value,
+      providerId: activeProvider.value,
       providerConfig,
     })
   }

--- a/apps/stage-web/src/components/Layouts/MobileInteractiveArea.vue
+++ b/apps/stage-web/src/components/Layouts/MobileInteractiveArea.vue
@@ -33,6 +33,7 @@ async function handleSend() {
   await send(messageInput.value, {
     chatProvider: providersStore.getProviderInstance(activeProvider.value) as ChatProvider,
     model: activeModel.value,
+    providerId: activeProvider.value,
     providerConfig,
   })
 }

--- a/docs/pages/en/guides/player2-api.md
+++ b/docs/pages/en/guides/player2-api.md
@@ -1,0 +1,3 @@
+# Player2 API
+
+Tools are disabled for this provider.


### PR DESCRIPTION
## Summary
- add `disableTools` option in LLM store
- provide `providerId` to chat store
- pass providerId to `send` in InteractiveArea components
- document that Player2 API disables tools
- fix chat message payload when preparing API request

## Testing
- `pnpm lint` *(fails: fetch failed)*
- `pnpm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_683e19e4784883278f4a8066a8027864